### PR TITLE
Add optional relay mode

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ export class MxBridgeConfig {
 	public database: MxBridgeConfigDatabase = new MxBridgeConfigDatabase();
 	public provisioning: MxBridgeConfigProvisioning = new MxBridgeConfigProvisioning();
 	public presence: MxBridgeConfigPresence = new MxBridgeConfigPresence();
-	public relay: boolean = false;
+	public relay: MxBridgeConfigRelay = new MxBridgeConfigRelay();
 
 	public applyConfig(newConfig: {[key: string]: any}, configLayer: {[key: string]: any} = this) {
 		Object.keys(newConfig).forEach((key) => {
@@ -53,4 +53,8 @@ class MxBridgeConfigProvisioning {
 class MxBridgeConfigPresence {
 	public enabled: boolean = true;
 	public interval: number = 500;
+}
+
+class MxBridgeConfigRelay {
+	public enabled: boolean = false;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,8 +48,6 @@ export class MxBridgeConfigDatabase {
 class MxBridgeConfigProvisioning {
 	public whitelist: string[] = [];
 	public blacklist: string[] = [];
-	public relayWhitelist: string[] = [];
-	public relayBlacklist: string[] = [];
 }
 
 class MxBridgeConfigPresence {
@@ -59,4 +57,6 @@ class MxBridgeConfigPresence {
 
 class MxBridgeConfigRelay {
 	public enabled: boolean = false;
+	public whitelist: string[] = [];
+	public blacklist: string[] = [];
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ export class MxBridgeConfig {
 	public database: MxBridgeConfigDatabase = new MxBridgeConfigDatabase();
 	public provisioning: MxBridgeConfigProvisioning = new MxBridgeConfigProvisioning();
 	public presence: MxBridgeConfigPresence = new MxBridgeConfigPresence();
+	public relay: boolean = false;
 
 	public applyConfig(newConfig: {[key: string]: any}, configLayer: {[key: string]: any} = this) {
 		Object.keys(newConfig).forEach((key) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,6 +48,8 @@ export class MxBridgeConfigDatabase {
 class MxBridgeConfigProvisioning {
 	public whitelist: string[] = [];
 	public blacklist: string[] = [];
+	public relayWhitelist: string[] = [];
+	public relayBlacklist: string[] = [];
 }
 
 class MxBridgeConfigPresence {

--- a/src/provisioner.ts
+++ b/src/provisioner.ts
@@ -83,19 +83,13 @@ export class Provisioner {
 	}
 
 	public canCreate(mxid: string): boolean {
-		for (const b of this.bridge.config.provisioning.blacklist) {
-			if (mxid.match(b)) {
-				return false;
-			}
-		}
-		let whitelisted = false;
-		for (const w of this.bridge.config.provisioning.whitelist) {
-			if (mxid.match(w)) {
-				whitelisted = true;
-				break;
-			}
-		}
-		return whitelisted;
+		return this.isWhitelisted(mxid, this.bridge.config.provisioning.whitelist,
+			this.bridge.config.provisioning.blacklist);
+	}
+
+	public canRelay(mxid: string): boolean {
+		return this.isWhitelisted(mxid, this.bridge.config.provisioning.relayWhitelist,
+			this.bridge.config.provisioning.relayBlacklist);
 	}
 
 	public async new(puppetMxid: string, data: any, userId?: string): Promise<number> {
@@ -163,5 +157,21 @@ export class Provisioner {
 			puppetId: data.puppetId,
 			desc: await this.bridge.hooks.getDesc(data.puppetId, data.data),
 		} as IProvisionerDesc;
+	}
+
+	private isWhitelisted(mxid: string, whitelist: string[], blacklist: string[]): boolean {
+		for (const b of blacklist) {
+			if (mxid.match(b)) {
+				return false;
+			}
+		}
+		let whitelisted = false;
+		for (const w of whitelist) {
+			if (mxid.match(w)) {
+				whitelisted = true;
+				break;
+			}
+		}
+		return whitelisted;
 	}
 }

--- a/src/provisioner.ts
+++ b/src/provisioner.ts
@@ -165,13 +165,11 @@ export class Provisioner {
 				return false;
 			}
 		}
-		let whitelisted = false;
 		for (const w of whitelist) {
 			if (mxid.match(w)) {
-				whitelisted = true;
-				break;
+				return true;
 			}
 		}
-		return whitelisted;
+		return false;
 	}
 }

--- a/src/provisioner.ts
+++ b/src/provisioner.ts
@@ -88,8 +88,8 @@ export class Provisioner {
 	}
 
 	public canRelay(mxid: string): boolean {
-		return this.isWhitelisted(mxid, this.bridge.config.provisioning.relayWhitelist,
-			this.bridge.config.provisioning.relayBlacklist);
+		return this.isWhitelisted(mxid, this.bridge.config.relay.whitelist,
+			this.bridge.config.relay.blacklist);
 	}
 
 	public async new(puppetMxid: string, data: any, userId?: string): Promise<number> {

--- a/src/puppetbridge.ts
+++ b/src/puppetbridge.ts
@@ -660,7 +660,8 @@ export class PuppetBridge extends EventEmitter {
 		if (userId in roomDisplaynameCache) {
 			return roomDisplaynameCache[userId];
 		}
-		const memberInfo = await this.appservice.botClient.getRoomStateEvent(roomId, "m.room.member", userId);
+		const client = await this.chanSync.getChanOp(roomId) || this.appservice.botClient;
+		const memberInfo = await client.getRoomStateEvent(roomId, "m.room.member", userId);
 		this.updateCachedRoomMemberInfo(roomId, userId, memberInfo);
 		return memberInfo;
 	}

--- a/src/puppetbridge.ts
+++ b/src/puppetbridge.ts
@@ -937,7 +937,7 @@ export class PuppetBridge extends EventEmitter {
 		if (event.sender !== puppetMxid) {
 			if (!this.config.relay.enabled) {
 				return; // relaying not enabled, don't allow message from other user
-			} else if (!this.provisioner.canCreate(event.sender)) {
+			} else if (!this.provisioner.canRelay(event.sender)) {
 				return; // no permissions to be relayed
 			}
 			await this.applyRelayFormatting(event.room_id, event.sender, event.content);

--- a/src/puppetbridge.ts
+++ b/src/puppetbridge.ts
@@ -900,7 +900,7 @@ export class PuppetBridge extends EventEmitter {
 		}
 		const puppetMxid = await this.provisioner.getMxid(room.puppetId);
 		if (event.sender !== puppetMxid) {
-			if (!this.config.relay) {
+			if (!this.config.relay.enabled) {
 				return; // relaying not enabled, don't allow message from other user
 			} else if (!this.provisioner.canCreate(event.sender)) {
 				return; // no permissions to be relayed

--- a/src/puppetbridge.ts
+++ b/src/puppetbridge.ts
@@ -935,13 +935,10 @@ export class PuppetBridge extends EventEmitter {
 		}
 		const puppetMxid = await this.provisioner.getMxid(room.puppetId);
 		if (event.sender !== puppetMxid) {
-			if (!this.config.relay.enabled) {
-				return; // relaying not enabled, don't allow message from other user
-			} else if (!this.provisioner.canRelay(event.sender)) {
-				return; // no permissions to be relayed
+			if (!this.config.relay.enabled || !this.provisioner.canRelay(event.sender)) {
+				return; // relaying not enabled or no permission to be relayed
 			}
 			await this.applyRelayFormatting(event.room_id, event.sender, event.content);
-			event.sender = puppetMxid;
 		}
 		log.info(`New message by ${event.sender} of type ${event.type} to process!`);
 		if (event.content.source === "remote") {


### PR DESCRIPTION
To enable, set `relay: true` in the config. When enabled, messages from unknown users will be sent to slack prefixed with `**mxid:**`