### PR TITLE
Add option for automatic double puppeting

### DIFF
--- a/src/botprovisioner.ts
+++ b/src/botprovisioner.ts
@@ -108,6 +108,13 @@ export class BotProvisioner {
 					await this.sendMessage(roomId, `ERROR: ${retData.error}`);
 					break;
 				}
+				if (!senderInfo.token) {
+					const token = await this.provisioner.loginWithSharedSecret(sender);
+					if (token) {
+						await this.provisioner.setToken(sender, token);
+						log.verbose("Enabled double puppeting for", sender, "with shared secret login");
+					}
+				}
 				if (puppetId === -1) {
 					// we need to create a new link
 					puppetId = await this.provisioner.new(sender, retData.data, retData.userId);

--- a/src/botprovisioner.ts
+++ b/src/botprovisioner.ts
@@ -112,7 +112,7 @@ export class BotProvisioner {
 					const token = await this.provisioner.loginWithSharedSecret(sender);
 					if (token) {
 						await this.provisioner.setToken(sender, token);
-						log.verbose("Enabled double puppeting for", sender, "with shared secret login");
+						log.info("Enabled double puppeting for", sender, "with shared secret login");
 					}
 				}
 				if (puppetId === -1) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,7 @@ class MxBridgeConfigBridge {
 	public port: number;
 	public domain: string;
 	public homeserverUrl: string;
+	public loginSharedSecret: string;
 }
 
 export class MxBridgeConfigLogging {

--- a/src/provisioner.ts
+++ b/src/provisioner.ts
@@ -1,4 +1,4 @@
-import crypto from "crypto";
+import { createHmac } from "crypto";
 import { MatrixAuth } from "matrix-bot-sdk";
 import { PuppetBridge } from "./puppetbridge";
 import { DbPuppetStore, IPuppet } from "./db/puppetstore";
@@ -47,7 +47,7 @@ export class Provisioner {
 			return null;
 		}
 
-		const hmac = crypto.createHmac("sha256", this.bridge.config.bridge.loginSharedSecret);
+		const hmac = createHmac("sha512", this.bridge.config.bridge.loginSharedSecret);
 		const password = hmac.update(new Buffer(mxid, "utf-8")).digest("hex");
 
 		const auth = new MatrixAuth(this.bridge.config.bridge.homeserverUrl);


### PR DESCRIPTION
When `bridge` -> `loginSharedSecret` is set in the config, the bridge will use [matrix-synapse-shared-secret-auth](https://github.com/devture/matrix-synapse-shared-secret-auth) to transparently enable double puppeting after the first successful `link` command.

Only works for users on the same homeserver as the bridge.