### PR TITLE
Correct mediaUrl capitalisation in sample config

### DIFF
--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -9,7 +9,7 @@ bridge:
   # URL where the bridge can connect to your homeserver
   homeserverUrl: http://localhost:8008
   # Optionally specify a different media URL used for the media store
-  #mediaURL: https://external-url.org
+  #mediaUrl: https://external-url.org
   # This enabled automatic double-puppeting:
   # A map for shared secrets of the homeserver URL to the shared secret
   # See https://github.com/devture/matrix-synapse-shared-secret-auth


### PR DESCRIPTION
The code has the correct capitalisation:

https://github.com/Sorunome/mx-puppet-bridge/blob/cc82d4c814f2740225e3a70ce2ba94513c5ef617/src/config.ts#L49