### PR TITLE
Ghost invite errors

### DIFF
--- a/src/remoteeventhandler.ts
+++ b/src/remoteeventhandler.ts
@@ -504,6 +504,12 @@ export class RemoteEventHandler {
 					}
 				}
 			} catch (err) {
+				try {
+					err.body = JSON.parse(err.body);
+				}
+				catch (e) {
+                    // If it's not valid JSON just leave it as-is
+				}
 				if (err.body && err.body.errcode === "M_FORBIDDEN" && err.body.error.includes("is already in the room")) {
 					log.verbose("Failed to invite user, as they are already in there");
 					this.ghostInviteCache.set(cacheKey, true);

--- a/src/remoteeventhandler.ts
+++ b/src/remoteeventhandler.ts
@@ -506,9 +506,8 @@ export class RemoteEventHandler {
 			} catch (err) {
 				try {
 					err.body = JSON.parse(err.body);
-				}
-				catch (e) {
-                    // If it's not valid JSON just leave it as-is
+				} catch (e) {
+					// If it's not valid JSON just leave it as-is
 				}
 				if (err.body && err.body.errcode === "M_FORBIDDEN" && err.body.error.includes("is already in the room")) {
 					log.verbose("Failed to invite user, as they are already in there");


### PR DESCRIPTION
I noticed I was getting more than the expected amount of `{"errcode":"M_FORBIDDEN","error":"@luke:localhost is already in the room."}` errors - i.e., on every message.

This hopefully fixes that by correctly interpreting the `err.body` as a JSON string, allowing the call to `this.ghostInviteCache.set` to occur.
