### PR TITLE
Move shared secret login to Provisioner.new

### DIFF
--- a/src/botprovisioner.ts
+++ b/src/botprovisioner.ts
@@ -138,16 +138,9 @@ export class BotProvisioner {
 						break;
 					}
 				}
-				if (!senderInfo.token) {
-					const token = await this.provisioner.loginWithSharedSecret(sender);
-					if (token) {
-						await this.provisioner.setToken(sender, token);
-						log.info("Enabled double puppeting for", sender, "with shared secret login");
-					}
-				}
 				let data: IPuppetData;
 				try {
-					data = (await Promise.resolve(retData.data)) || {};
+					data = (await retData.data) || {};
 				} catch (err) {
 					log.warn("Failed to create/update link", err);
 					await this.sendMessage(roomId, `ERROR: ${err}`);

--- a/src/provisioner.ts
+++ b/src/provisioner.ts
@@ -185,6 +185,14 @@ export class Provisioner {
 		if (!this.canCreate(puppetMxid)) {
 			return -1;
 		}
+		const userInfo = await this.puppetStore.getOrCreateMxidInfo(puppetMxid);
+		if (!userInfo.token) {
+			userInfo.token = await this.loginWithSharedSecret(puppetMxid);
+			if (userInfo.token) {
+				await this.puppetStore.setMxidInfo(userInfo);
+				log.info("Enabled double puppeting for", puppetMxid, "with shared secret login");
+			}
+		}
 		const isGlobal = Boolean(this.bridge.protocol.features.globalNamespace);
 		const puppetId = await this.puppetStore.new(puppetMxid, data, userId, isGlobal);
 		log.info(`Created new puppet with id ${puppetId}`);


### PR DESCRIPTION
Previously it was in the link command handler, which meant that logging in via the provisioning API would not activate double puppeting.