### PR TITLE
Strip nested replies from matrix replies

### DIFF
--- a/src/remoteeventhandler.ts
+++ b/src/remoteeventhandler.ts
@@ -271,10 +271,13 @@ export class RemoteEventHandler {
 						const bodyParts = info.message.body.split("\n");
 						bodyParts[0] = `${info.message.emote ? "* " : ""}<${info.user.mxid}> ${bodyParts[0]}`;
 						send.body = `${bodyParts.map((l) => `> ${l}`).join("\n")}\n\n${send.body}`;
+						const matrixReplyRegex = /^<mx-reply>.*<\/mx-reply>/gs;
+						const messageWithoutNestedReplies = info.message.formattedBody?.replace(matrixReplyRegex, "");
+
 						const richHeader = `<mx-reply><blockquote>
 	<a href="https://matrix.to/#/${mxid}/${origEventId}">In reply to</a>
 	${info.message.emote ? "* " : ""}<a href="https://matrix.to/#/${info.user.mxid}">${info.user.mxid}</a>
-	<br>${info.message.formattedBody}
+	<br>${messageWithoutNestedReplies}
 </blockquote></mx-reply>`;
 						send.formatted_body = richHeader + send.formatted_body;
 					} else if (info.file) {


### PR DESCRIPTION
When replying to another reply, bridges based on mx-puppet-bridge will copy all nested replies together with replied message.

Riot clients do not seem to handle this well, which causes issues such as https://github.com/Sorunome/mx-puppet-slack/issues/61.

This fixes the issue by stripping all nested replies before sending in new reply.