### PR TITLE
mute non-relayable users

### DIFF
--- a/src/botprovisioner.ts
+++ b/src/botprovisioner.ts
@@ -646,6 +646,27 @@ Usage: \`fixghosts <room resolvable>\``,
 			withPid: false,
 			inRoom: true,
 		});
+		this.registerCommand("fixmute", {
+			fn: async (sender: string, param: string, sendMessage: SendMessageFn, roomId?: string) => {
+				const roomParts = await this.bridge.roomSync.resolve(roomId || param);
+				if (!roomParts) {
+					await sendMessage("Room not resolvable");
+					return;
+				}
+				const room = await this.bridge.roomSync.maybeGet(roomParts);
+				if (!room) {
+					await sendMessage("Room not found");
+					return;
+				}
+				await sendMessage("Fixing muted user...");
+				await this.provisioner.adjustMuteIfInRoom(sender, room.mxid);
+			},
+			help: `Fix the power levels according to puppet & relay availability in the bridged room.
+
+Usage: \`fixmute <room resolvable>\``,
+			withPid: false,
+			inRoom: true,
+		});
 		this.registerCommand("resendbridgeinfo", {
 			fn: async (sender: string, param: string, sendMessage: SendMessageFn) => {
 				await sendMessage("Re-sending bridge information state events...");

--- a/src/db/roomstore.ts
+++ b/src/db/roomstore.ts
@@ -45,6 +45,18 @@ export class DbRoomStore {
 		};
 	}
 
+	public async getAll(): Promise<IRoomStoreEntry[]> {
+		const rows = await this.db.All("SELECT * FROM room_store");
+		const results: IRoomStoreEntry[] = [];
+		for (const row of rows) {
+			const res = this.getFromRow(row);
+			if (res) {
+				results.push(res);
+			}
+		}
+		return results;
+	}
+
 	public async getByRemote(puppetId: number, roomId: string): Promise<IRoomStoreEntry | null> {
 		const cached = this.remoteCache.get(`${puppetId};${roomId}`);
 		if (cached) {

--- a/src/matrixeventhandler.ts
+++ b/src/matrixeventhandler.ts
@@ -182,6 +182,11 @@ export class MatrixEventHandler {
 	private async handleUserJoinEvent(roomId: string, event: MembershipEvent) {
 		const userId = event.membershipFor;
 		log.info(`Got new user join event from ${userId} in ${roomId}...`);
+		try {
+			await this.bridge.provisioner.adjustMute(userId, roomId);
+		} catch (err) {
+			log.error("Error checking mute status", err.error || err.body || err);
+		}
 		const room = await this.getRoomParts(roomId, event.sender);
 		if (!room) {
 			log.verbose("Room not found, ignoring...");

--- a/test/test_matrixeventhandler.ts
+++ b/test/test_matrixeventhandler.ts
@@ -306,6 +306,7 @@ function getHandler(opts?: IHandlerOpts) {
 				return [];
 			},
 			canRelay: (mxid) => !mxid.startsWith("@bad"),
+			adjustMute: async (userId, room) => {},
 		},
 		eventSync: {
 			getRemote: (room, mxid) => {

--- a/test/test_provisioner.ts
+++ b/test/test_provisioner.ts
@@ -122,6 +122,11 @@ function getProvisioner() {
 				PUPPETSTORE_DELETE = puppetId;
 			},
 		},
+		roomStore: {
+			getAll: async () => {
+				return [];
+			},
+		},
 		config: {
 			bridge: {
 				loginSharedSecretMap: {


### PR DESCRIPTION
This adjusts powel levels to -1 or 0 based on whether the user can be relayed.
Power leves are adjusted when joining a room, (un-)linking a puppet, and when calling the "fixmute" command.

There are two aspect about this code where I am unsatisfied, but was not able to do any better with the available data & hooks:
- On linking a puppet, after 10 seconds `listrooms` is called to get all rooms where a user may need to be unmuted.
- On unlinking a puppet, all rooms from all puppets are checked wether the user needs to be muted.