### PR TITLE
wait for postgres, possibly fixes https://github.com/matrix-discord/mx-puppet-discord/issues/78

### DIFF
--- a/src/db/postgres.ts
+++ b/src/db/postgres.ts
@@ -37,7 +37,7 @@ export class Postgres implements IDatabaseConnector {
 	constructor(private connectionString: string) {
 
 	}
-	public async Open() {
+	public async Open(): Promise<void> {
 		// Hide username:password
 		const logConnString = this.connectionString.substr(
 			this.connectionString.indexOf("@") || 0,

--- a/src/db/postgres.ts
+++ b/src/db/postgres.ts
@@ -37,13 +37,15 @@ export class Postgres implements IDatabaseConnector {
 	constructor(private connectionString: string) {
 
 	}
-	public Open() {
+	public async Open() {
 		// Hide username:password
 		const logConnString = this.connectionString.substr(
 			this.connectionString.indexOf("@") || 0,
 		);
 		log.info(`Opening ${logConnString}`);
 		this.db = pgp(this.connectionString);
+		// Wait for postgres to be ready by returning a promise for a connection
+		return this.db.connect();
 	}
 
 	public async Get(sql: string, parameters?: ISqlCommandParameters): Promise<ISqlRow|null> {

--- a/src/store.ts
+++ b/src/store.ts
@@ -202,7 +202,7 @@ export class Store {
 			this.db = new SQLite3(this.config.filename);
 		}
 		try {
-			this.db.Open();
+			await this.db.Open();
 			this.pRoomStore = new DbRoomStore(this.db);
 			this.pUserStore = new DbUserStore(this.db);
 			this.pGroupStore = new DbGroupStore(this.db);

--- a/src/store.ts
+++ b/src/store.ts
@@ -202,7 +202,7 @@ export class Store {
 			this.db = new SQLite3(this.config.filename);
 		}
 		try {
-			await this.db.Open();
+			await Promise.resolve(this.db.Open());
 			this.pRoomStore = new DbRoomStore(this.db);
 			this.pUserStore = new DbUserStore(this.db);
 			this.pGroupStore = new DbGroupStore(this.db);


### PR DESCRIPTION
Hello!

  This PR ensures that we always wait for postgres to be connected before we continue on in the code - this prevents a problem where `getSchemaVersion` fails, and then returns 0 as the schema version, which causes some thrashing of the database :( - this ensures we never run getSchemaVersion() until we know that query will fail for non-connection reasons. Rebooting a machine is a good example where postgres and the bridge will both start at the same time, which can lead to this issue.

  I'm still testing to ensure that this 100% resolves https://github.com/matrix-discord/mx-puppet-discord/issues/78 (I think it will), but at any rate it's probably a good idea to ensure PG is ready before running :)

Thanks!