### PR TITLE
Add prometheus metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -732,6 +732,11 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+    },
     "bl": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
@@ -3561,6 +3566,14 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "prom-client": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.0.0.tgz",
+      "integrity": "sha512-M7ZNjIO6x+2R/vjSD13yjJPjpoZA8eEwH2Bp2Re0/PvzozD7azikv+SaBtZes4Q1ca/xHjZ4RSCuTag3YZLg1A==",
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
+    },
     "proxy-addr": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -4116,6 +4129,14 @@
             "util-deprecate": "^1.0.1"
           }
         }
+      }
+    },
+    "tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "requires": {
+        "bintrees": "1.0.1"
       }
     },
     "test-exclude": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "js-yaml": "^3.13.1",
     "markdown-it": "^9.1.0",
     "pg-promise": "^10.5.0",
+    "prom-client": "^13.0.0",
     "unescape": "^1.0.1",
     "uuid": "^3.4.0",
     "winston": "^3.2.1",

--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -135,6 +135,15 @@ namePatterns:
   room: :name
   group: :name
 
+# Prometheus metrics configuration
+metrics:
+  # If enabled, the metrics are served at http://localhost:$port$path
+  enabled: false
+  # On which port the prometheus metrics will be served
+  port: 8000
+  # Path on which the metrics are available, the default is /metrics
+  path: "/metrics"
+
 limits:
   # Up to how many users should be auto-joined on room creation? -1 to disable
   # Defaults to 200

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,7 @@ export class Config {
 	public bridge: BridgeConfig = new BridgeConfig();
 	public logging: LoggingConfig = new LoggingConfig();
 	public database: DatabaseConfig = new DatabaseConfig();
+	public metrics: MetricsConfig = new MetricsConfig();
 	public provisioning: ProvisioningConfig = new ProvisioningConfig();
 	public presence: PresenceConfig = new PresenceConfig();
 	public relay: RelayConfig = new RelayConfig();
@@ -76,6 +77,12 @@ export class LoggingFileConfig extends LoggingInterfaceConfig {
 	public maxFiles: string = "14d";
 	public maxSize: string|number = "50m";
 	public datePattern: string = "YYYY-MM-DD";
+}
+
+export class MetricsConfig {
+	public enabled: boolean = false;
+	public port: number = 8000;
+	public path: string = "/metrics";
 }
 
 export class DatabaseConfig {

--- a/src/db/connector.ts
+++ b/src/db/connector.ts
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import * as prometheus from "prom-client";
+
 type SQLTYPES = number | boolean | string | null;
 
 export interface ISqlCommandParameters {
@@ -26,6 +28,7 @@ export interface ISqlRow {
 
 export interface IDatabaseConnector {
 	type: string;
+	latency: prometheus.Histogram<string>;
 	Open(): void;
 	Get(sql: string, parameters?: ISqlCommandParameters): Promise<ISqlRow|null>;
 	All(sql: string, parameters?: ISqlCommandParameters): Promise<ISqlRow[]>;

--- a/src/db/eventstore.ts
+++ b/src/db/eventstore.ts
@@ -19,26 +19,32 @@ const log = new Log("DbEventStore");
 export class DbEventStore {
 	constructor(
 		private db: IDatabaseConnector,
+		private protocol: string = "unknown",
 	) { }
 
 	public async insert(puppetId: number, roomId: string, matrixId: string, remoteId: string) {
+		const stopTimer = this.db.latency.startTimer(this.labels("insert"));
 		await this.db.Run("INSERT INTO event_store (puppet_id, room_id, matrix_id, remote_id) VALUES ($p, $room, $m, $r)", {
 			p: puppetId,
 			room: roomId,
 			m: matrixId,
 			r: remoteId,
 		});
+		stopTimer();
 	}
 
 	public async remove(puppetId: number, roomId: string, remoteId: string) {
+		const stopTimer = this.db.latency.startTimer(this.labels("remove"));
 		await this.db.Run("DELETE FROM event_store WHERE puppet_id = $p AND room_id = $room AND remote_id = $r", {
 			p: puppetId,
 			room: roomId,
 			r: remoteId,
 		});
+		stopTimer();
 	}
 
 	public async getMatrix(puppetId: number, roomId: string, remoteId: string): Promise<string[]> {
+		const stopTimer = this.db.latency.startTimer(this.labels("select_matrix"));
 		const result: string[] = [];
 		const rows = await this.db.All("SELECT * FROM event_store WHERE puppet_id=$p AND room_id = $room AND remote_id=$r", {
 			p: puppetId,
@@ -48,10 +54,12 @@ export class DbEventStore {
 		for (const row of rows) {
 			result.push(row.matrix_id as string);
 		}
+		stopTimer();
 		return result;
 	}
 
 	public async getRemote(puppetId: number, roomId: string, matrixId: string): Promise<string[]> {
+		const stopTimer = this.db.latency.startTimer(this.labels("select_remote"));
 		const result: string[] = [];
 		const rows = await this.db.All(
 			"SELECT * FROM event_store WHERE puppet_id = $p AND room_id = $room AND matrix_id = $m", {
@@ -62,6 +70,16 @@ export class DbEventStore {
 		for (const row of rows) {
 			result.push(row.remote_id as string);
 		}
+		stopTimer();
 		return result;
+	}
+
+	private labels(queryName: string): object {
+		return {
+			protocol: this.protocol,
+			engine: this.db.type,
+			table: "event_store",
+			type: queryName,
+		};
 	}
 }

--- a/src/db/roomstore.ts
+++ b/src/db/roomstore.ts
@@ -25,13 +25,16 @@ export class DbRoomStore {
 	private remoteCache: TimedCache<string, IRoomStoreEntry>;
 	private mxidCache: TimedCache<string, IRoomStoreEntry>;
 	private opCache: TimedCache<string, string>;
+	private protocol: string;
 	constructor(
 		private db: IDatabaseConnector,
 		cache: boolean = true,
+		protocol: string = "unknown",
 	) {
 		this.remoteCache = new TimedCache(cache ? ROOM_CACHE_LIFETIME : 0);
 		this.mxidCache = new TimedCache(cache ? ROOM_CACHE_LIFETIME : 0);
 		this.opCache = new TimedCache(cache ? ROOM_CACHE_LIFETIME : 0);
+		this.protocol = protocol;
 	}
 
 	public newData(mxid: string, roomId: string, puppetId: number): IRoomStoreEntry {
@@ -46,6 +49,7 @@ export class DbRoomStore {
 	}
 
 	public async getAll(): Promise<IRoomStoreEntry[]> {
+		const stopTimer = this.db.latency.startTimer(this.labels("select_all"));
 		const rows = await this.db.All("SELECT * FROM room_store");
 		const results: IRoomStoreEntry[] = [];
 		for (const row of rows) {
@@ -54,10 +58,12 @@ export class DbRoomStore {
 				results.push(res);
 			}
 		}
+		stopTimer();
 		return results;
 	}
 
 	public async getByRemote(puppetId: number, roomId: string): Promise<IRoomStoreEntry | null> {
+		const stopTimer = this.db.latency.startTimer(this.labels("select_by_remote"));
 		const cached = this.remoteCache.get(`${puppetId};${roomId}`);
 		if (cached) {
 			return cached;
@@ -67,10 +73,12 @@ export class DbRoomStore {
 			room_id: roomId,
 			puppet_id: puppetId,
 		});
+		stopTimer();
 		return this.getFromRow(row);
 	}
 
 	public async getByPuppetId(puppetId: number): Promise<IRoomStoreEntry[]> {
+		const stopTimer = this.db.latency.startTimer(this.labels("select_by_puppet"));
 		const rows = await this.db.All(
 			"SELECT * FROM room_store WHERE puppet_id = $puppet_id", {
 			puppet_id: puppetId,
@@ -82,10 +90,12 @@ export class DbRoomStore {
 				results.push(res);
 			}
 		}
+		stopTimer();
 		return results;
 	}
 
 	public async getByMxid(mxid: string): Promise<IRoomStoreEntry | null> {
+		const stopTimer = this.db.latency.startTimer(this.labels("select_by_mxid"));
 		const cached = this.mxidCache.get(mxid);
 		if (cached) {
 			return cached;
@@ -93,10 +103,12 @@ export class DbRoomStore {
 		const row = await this.db.Get(
 			"SELECT * FROM room_store WHERE mxid = $mxid", { mxid },
 		);
+		stopTimer();
 		return this.getFromRow(row);
 	}
 
 	public async set(data: IRoomStoreEntry) {
+		const stopTimer = this.db.latency.startTimer(this.labels("insert_update"));
 		const exists = await this.db.Get(
 			"SELECT * FROM room_store WHERE mxid = $mxid", {mxid: data.mxid},
 		);
@@ -164,9 +176,11 @@ export class DbRoomStore {
 		});
 		this.remoteCache.set(`${data.puppetId};${data.roomId}`, data);
 		this.mxidCache.set(data.mxid, data);
+		stopTimer();
 	}
 
 	public async delete(data: IRoomStoreEntry) {
+		const stopTimer = this.db.latency.startTimer(this.labels("delete"));
 		await this.db.Run(
 			"DELETE FROM room_store WHERE mxid = $mxid", { mxid: data.mxid },
 		);
@@ -176,9 +190,11 @@ export class DbRoomStore {
 		this.remoteCache.delete(`${data.puppetId};${data.roomId}`);
 		this.mxidCache.delete(data.mxid);
 		this.opCache.delete(data.mxid);
+		stopTimer();
 	}
 
 	public async toGlobalNamespace(puppetId: number, roomId: string) {
+		const stopTimer = this.db.latency.startTimer(this.labels("update_namespace"));
 		const exists = await this.getByRemote(-1, roomId);
 		if (exists) {
 			return;
@@ -194,15 +210,18 @@ export class DbRoomStore {
 		this.remoteCache.delete(`${puppetId};${roomId}`);
 		this.mxidCache.delete(room.mxid);
 		this.opCache.delete(room.mxid);
+		stopTimer();
 	}
 
 	public async setRoomOp(roomMxid: string, userMxid: string) {
+		const stopTimer = this.db.latency.startTimer(this.labels("update_room_op"));
 		const row = await this.db.Get("SELECT * FROM chan_op WHERE chan_mxid=$chan LIMIT 1", {
 			chan: roomMxid,
 		});
 		if (row) {
 			if ((row.user_mxid as string) === userMxid) {
 				// nothing to do, we are already set
+				stopTimer();
 				return;
 			}
 			await this.db.Run("DELETE FROM chan_op WHERE chan_mxid=$chan", {
@@ -214,9 +233,11 @@ export class DbRoomStore {
 			user: userMxid,
 		});
 		this.opCache.set(roomMxid, userMxid);
+		stopTimer();
 	}
 
 	public async getRoomOp(roomMxid: string): Promise<string|null> {
+		const stopTimer = this.db.latency.startTimer(this.labels("select_room_op"));
 		const cached = this.opCache.get(roomMxid);
 		if (cached) {
 			return cached;
@@ -229,6 +250,7 @@ export class DbRoomStore {
 		}
 		const userMxid = row.user_mxid as string;
 		this.opCache.set(roomMxid, userMxid);
+		stopTimer();
 		return userMxid;
 	}
 
@@ -255,5 +277,14 @@ export class DbRoomStore {
 		this.remoteCache.set(`${data.puppetId};${data.roomId}`, data);
 		this.mxidCache.set(data.mxid, data);
 		return data;
+	}
+
+	private labels(queryName: string): object {
+		return {
+			protocol: this.protocol,
+			engine: this.db.type,
+			table: "room_store",
+			type: queryName,
+		};
 	}
 }

--- a/src/db/userstore.ts
+++ b/src/db/userstore.ts
@@ -37,6 +37,26 @@ export class DbUserStore {
 		};
 	}
 
+	public async getAll() {
+		const results: object[] = [];
+		const rows = await this.db.All(
+			"SELECT * FROM user_store;",
+		);
+		if (!rows) {
+			return [];
+		}
+		for (const r of rows) {
+			const data = {
+				name: r.name as string | null,
+				avatarUrl: r.avatar_url as string | null,
+				avatarMxc: r.avatar_mxc as string | null,
+				avatarHash: r.avatar_hash as string | null,
+			};
+			results.push(data);
+		}
+		return results;
+	}
+
 	public async get(puppetId: number, userId: string): Promise<IUserStoreEntry | null> {
 		const cacheKey = `${puppetId};${userId}`;
 		const cached = this.usersCache.get(cacheKey);

--- a/src/db/userstore.ts
+++ b/src/db/userstore.ts
@@ -23,11 +23,14 @@ const USERS_CACHE_LIFETIME = 1000 * 60 * 60 * 24;
 
 export class DbUserStore {
 	private usersCache: TimedCache<string, IUserStoreEntry>;
+	private protocol: string;
 	constructor(
 		private db: IDatabaseConnector,
 		cache: boolean = true,
+		protocol: string = "unknown",
 	) {
 		this.usersCache = new TimedCache(cache ? USERS_CACHE_LIFETIME : 0);
+		this.protocol = protocol;
 	}
 
 	public newData(puppetId: number, userId: string): IUserStoreEntry {
@@ -37,8 +40,9 @@ export class DbUserStore {
 		};
 	}
 
-	public async getAll() {
-		const results: object[] = [];
+	public async getAll(): Promise<IUserStoreEntry[]> {
+		const stopTimer = this.db.latency.startTimer(this.labels("select_all"));
+		const results: IUserStoreEntry[] = [];
 		const rows = await this.db.All(
 			"SELECT * FROM user_store;",
 		);
@@ -48,16 +52,20 @@ export class DbUserStore {
 		for (const r of rows) {
 			const data = {
 				name: r.name as string | null,
+				userId: r.user_id as string,
+				puppetId: r.puppet_id as number,
 				avatarUrl: r.avatar_url as string | null,
 				avatarMxc: r.avatar_mxc as string | null,
 				avatarHash: r.avatar_hash as string | null,
 			};
 			results.push(data);
 		}
+		stopTimer();
 		return results;
 	}
 
 	public async get(puppetId: number, userId: string): Promise<IUserStoreEntry | null> {
+		const stopTimer = this.db.latency.startTimer(this.labels("select"));
 		const cacheKey = `${puppetId};${userId}`;
 		const cached = this.usersCache.get(cacheKey);
 		if (cached) {
@@ -75,10 +83,12 @@ export class DbUserStore {
 		data.avatarMxc = row.avatar_mxc as string | null;
 		data.avatarHash = row.avatar_hash as string | null;
 		this.usersCache.set(cacheKey, data);
+		stopTimer();
 		return data;
 	}
 
 	public async set(data: IUserStoreEntry) {
+		const stopTimer = this.db.latency.startTimer(this.labels("insert_update"));
 		const exists = await this.db.Get(
 			"SELECT 1 FROM user_store WHERE user_id = $id AND puppet_id = $pid", {id: data.userId, pid: data.puppetId},
 		);
@@ -117,9 +127,11 @@ export class DbUserStore {
 		});
 		const cacheKey = `${data.puppetId};${data.userId}`;
 		this.usersCache.set(cacheKey, data);
+		stopTimer();
 	}
 
 	public async delete(data: IUserStoreEntry) {
+		const stopTimer = this.db.latency.startTimer(this.labels("delete"));
 		await this.db.Run("DELETE FROM user_store WHERE user_id = $user_id AND puppet_id = $puppet_id", {
 			user_id: data.userId,
 			puppet_id: data.puppetId,
@@ -131,6 +143,7 @@ export class DbUserStore {
 		});
 		const cacheKey = `${data.puppetId};${data.userId}`;
 		this.usersCache.delete(cacheKey);
+		stopTimer();
 	}
 
 	public newRoomOverrideData(puppetId: number, userId: string, roomId: string): IUserStoreRoomOverrideEntry {
@@ -146,6 +159,7 @@ export class DbUserStore {
 		userId: string,
 		roomId: string,
 	): Promise<IUserStoreRoomOverrideEntry | null> {
+		const stopTimer = this.db.latency.startTimer(this.labels("get_room_override"));
 		const row = await this.db.Get(
 			"SELECT * FROM user_store_room_override WHERE user_id = $uid AND puppet_id = $pid AND room_id = $rid", {
 			uid: userId,
@@ -155,10 +169,12 @@ export class DbUserStore {
 		if (!row) {
 			return null;
 		}
+		stopTimer();
 		return this.getRoomOverrideFromRow(row);
 	}
 
 	public async setRoomOverride(data: IUserStoreRoomOverrideEntry) {
+		const stopTimer = this.db.latency.startTimer(this.labels("insert_update_room_override"));
 		const exists = await this.db.Get(
 			"SELECT 1 FROM user_store_room_override WHERE user_id = $uid AND puppet_id = $pid AND room_id = $rid", {
 			uid: data.userId,
@@ -201,9 +217,11 @@ export class DbUserStore {
 			avatar_mxc: data.avatarMxc || null,
 			avatar_hash: data.avatarHash || null,
 		});
+		stopTimer();
 	}
 
 	public async getAllRoomOverrides(puppetId: number, userId: string): Promise<IUserStoreRoomOverrideEntry[]> {
+		const stopTimer = this.db.latency.startTimer(this.labels("select_all_room_override"));
 		const result: IUserStoreRoomOverrideEntry[] = [];
 		const rows = await this.db.All(
 			"SELECT * FROM user_store_room_override WHERE user_id = $uid AND puppet_id = $pid", {
@@ -216,6 +234,7 @@ export class DbUserStore {
 				result.push(entry);
 			}
 		}
+		stopTimer();
 		return result;
 	}
 
@@ -233,5 +252,14 @@ export class DbUserStore {
 		data.avatarMxc = row.avatar_mxc as string | null;
 		data.avatarHash = row.avatar_hash as string | null;
 		return data;
+	}
+
+	private labels(queryName: string): object {
+		return {
+			protocol: this.protocol,
+			engine: this.db.type,
+			table: "user_store",
+			type: queryName,
+		};
 	}
 }

--- a/src/provisioner.ts
+++ b/src/provisioner.ts
@@ -321,6 +321,7 @@ export class Provisioner {
 		await this.puppetStore.deleteStatusRoom(mxid);
 		// alright, we did all the verifying, time to actually bridge this room!
 		await this.bridge.roomSync.rebridge(mxid, newRoomParts);
+		this.bridge.metrics.room.inc({ type: "group", protocol: this.bridge.protocol.id });
 	}
 
 	public async unbridgeRoom(userId: string, ident: RemoteRoomResolvable): Promise<boolean> {
@@ -337,6 +338,7 @@ export class Provisioner {
 		}
 		// alright, unbridge the room
 		await this.bridge.roomSync.delete(roomParts, true);
+		this.bridge.metrics.room.dec({ type: "group", protocol: this.bridge.protocol.id });
 		return true;
 	}
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -203,13 +203,13 @@ export class Store {
 		}
 		try {
 			this.db.Open();
-			this.pRoomStore = new DbRoomStore(this.db);
-			this.pUserStore = new DbUserStore(this.db);
-			this.pGroupStore = new DbGroupStore(this.db);
-			this.pPuppetStore = new DbPuppetStore(this.db);
-			this.pEventStore = new DbEventStore(this.db);
-			this.pReactionStore = new DbReactionStore(this.db);
-			this.pEmoteStore = new DbEmoteStore(this.db);
+			this.pRoomStore = new DbRoomStore(this.db, undefined, this.bridge.protocol?.id);
+			this.pUserStore = new DbUserStore(this.db, undefined, this.bridge.protocol?.id);
+			this.pGroupStore = new DbGroupStore(this.db, undefined, this.bridge.protocol?.id);
+			this.pPuppetStore = new DbPuppetStore(this.db, undefined, this.bridge.protocol?.id);
+			this.pEventStore = new DbEventStore(this.db, this.bridge.protocol?.id);
+			this.pReactionStore = new DbReactionStore(this.db, this.bridge.protocol?.id);
+			this.pEmoteStore = new DbEmoteStore(this.db, this.bridge.protocol?.id);
 		} catch (ex) {
 			log.error("Error opening database:", ex);
 			throw new Error("Couldn't open database. The appservice won't be able to continue.");

--- a/test/db/test_eventstore.ts
+++ b/test/db/test_eventstore.ts
@@ -14,17 +14,23 @@ limitations under the License.
 import { expect } from "chai";
 import { DbEventStore } from "../../src/db/eventstore";
 import { Store } from "../../src/store";
+import * as prometheus from "prom-client";
 
 // we are a test file and thus our linting rules are slightly different
 // tslint:disable:no-unused-expression max-file-line-count no-any no-magic-numbers no-string-literal
 
 async function getStore(): Promise<DbEventStore> {
+	prometheus.register.clear();
 	const store = new Store({
 		filename: ":memory:",
 	} as any, {} as any);
 	await store.init();
 	return new DbEventStore(store.db);
 }
+
+beforeEach("Prometheus clean up", () => {
+	prometheus.register.clear();
+});
 
 describe("DbEventStore", () => {
 	it("should insert things", async () => {

--- a/test/test_matrixeventhandler.ts
+++ b/test/test_matrixeventhandler.ts
@@ -17,6 +17,7 @@ import {
 	RoomEvent, RoomEventContent, MembershipEvent, RedactionEvent, MessageEventContent, MessageEvent,
 	FileMessageEventContent, TextualMessageEventContent,
 } from "@sorunome/matrix-bot-sdk";
+import * as prometheus from "prom-client";
 import { MessageDeduplicator } from "../src/structures/messagededuplicator";
 
 // we are a test file and thus our linting rules are slightly different
@@ -348,7 +349,9 @@ function getHandler(opts?: IHandlerOpts) {
 		typingHandler: {
 			deduplicator: new MessageDeduplicator(DEDUPLICATOR_TIMEOUT, DEDUPLICATOR_TIMEOUT + DEDUPLICATOR_TIMEOUT),
 		},
+		metrics: {},
 	} as any;
+	prometheus.register.clear();
 	return new MatrixEventHandler(bridge);
 }
 

--- a/test/test_remoteeventhandler.ts
+++ b/test/test_remoteeventhandler.ts
@@ -13,6 +13,7 @@ limitations under the License.
 
 import { expect } from "chai";
 import * as proxyquire from "proxyquire";
+import * as prometheus from "prom-client";
 import { MessageDeduplicator } from "../src/structures/messagededuplicator";
 
 // we are a test file and thus our linting rules are slightly different
@@ -250,6 +251,7 @@ function getHandler(opts?: IHandlerOpts) {
 				},
 			};
 		},
+		metrics: {},
 	} as any;
 	const RemoteEventHandler = proxyquire.load("../src/remoteeventhandler", {
 		"./util": { Util: {
@@ -257,6 +259,7 @@ function getHandler(opts?: IHandlerOpts) {
 			GetMimeType: (buffer) => buffer.toString(),
 		}},
 	}).RemoteEventHandler;
+	prometheus.register.clear();
 	return new RemoteEventHandler(bridge);
 }
 


### PR DESCRIPTION
Continuation of #71

The following metrics are available for scraping with prometheus:

- `bridge_rooms_total`: labeled by protocol and type (dm, group)

- `bridge_puppets_total`: labeled by protocol, how many puppets
exist (aka remote accounts matrix users have linked)

- `bridge_remote_users_total`: labeled by protocol, how many
remote users (sometimes called "ghosts") exist

- `bridge_messages_total`: labeled by protocol and type, so
`count(bridge_messages_total) by (protocol, type)` is possible

- `bridge_matrix_events_total`: labeled by protocol and type,
the total amount of matrix events processed since startup

- `bridge_matrix_event_errors_total`: labeled by protocol,
how many matrix events resulted in an exception during bridging

- `bridge_matrix_event_seconds`: histogram by protocol and type
of the time spent processing a matrix event to be bridged

- `bridge_remote_update_seconds`: histogram by protocol and type
of the time spent bridging remote events into matrix

Labeling by the protocol id enables you to have a single
scrape config in prometheus with many mx-puppet-* bridges
as targets, and easily visualizing global bridge activity
with f.ex. grafana.

For `bride_connected` to work, the implementing bridge needs
to call `trackConnectionStatus` on connect/disconnect.